### PR TITLE
Edit translation to make it grammatically correct in Spanish

### DIFF
--- a/xml/System.Net.Sockets/TcpClient.xml
+++ b/xml/System.Net.Sockets/TcpClient.xml
@@ -44,21 +44,21 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- La <xref:System.Net.Sockets.TcpClient> clase proporciona métodos sencillos para conectarse, enviar, y recibir transmitir datos a través de una red en modo de bloqueo sincrónico.  
+ La clase <xref:System.Net.Sockets.TcpClient> proporciona métodos sencillos para conectarse, enviar, y recibir transmitir datos a través de una red en modo de bloqueo sincrónico.  
   
- En orden para <xref:System.Net.Sockets.TcpClient> conectarse e intercambiar datos, un <xref:System.Net.Sockets.TcpListener> o <xref:System.Net.Sockets.Socket> creado con el TCP <xref:System.Net.Sockets.ProtocolType> debe estar escuchando solicitudes de conexión entrantes. Puede conectarse a este agente de escucha en una de las dos maneras siguientes:  
+ Para que <xref:System.Net.Sockets.TcpClient> pueda conectarse e intercambiar datos, un <xref:System.Net.Sockets.TcpListener> o <xref:System.Net.Sockets.Socket> creado con el <xref:System.Net.Sockets.ProtocolType> TCP debe estar escuchando solicitudes de conexión entrantes. Puede conectarse a este agente de escucha en una de las dos maneras siguientes:  
   
--   Crear un <xref:System.Net.Sockets.TcpClient> y llame a uno de los tres disponibles <xref:System.Net.Sockets.TcpClient.Connect%2A> métodos.  
+-   Crear un <xref:System.Net.Sockets.TcpClient> y llamar a uno de los tres métodos <xref:System.Net.Sockets.TcpClient.Connect%2A> disponibles.  
   
 -   Crear un <xref:System.Net.Sockets.TcpClient> con el nombre de host y número de puerto del host remoto. Este constructor intentará automáticamente una conexión.  
   
 > [!NOTE]
->  Si desea enviar datagramas sin conexión en modo de bloqueo sincrónico, utilice el <xref:System.Net.Sockets.UdpClient> clase.  
+>  Si desea enviar datagramas sin conexión en modo de bloqueo sincrónico, utilice la clase <xref:System.Net.Sockets.UdpClient>.  
   
    
   
 ## Examples  
- El siguiente ejemplo de código establece un <xref:System.Net.Sockets.TcpClient> conexión.  
+ El siguiente ejemplo de código establece una conexión <xref:System.Net.Sockets.TcpClient>.  
   
  [!code-cpp[System.Net.Sockets.TcpClient#1](~/samples/snippets/cpp/VS_Snippets_Remoting/System.Net.Sockets.TcpClient/CPP/tcpclient.cpp#1)]
  [!code-csharp[System.Net.Sockets.TcpClient#1](~/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Sockets.TcpClient/CS/tcpclient.cs#1)]
@@ -68,7 +68,7 @@
     </remarks>
     <permission cref="T:System.Net.SocketPermission">Permiso para establecer una conexión saliente o Aceptar una solicitud entrante.</permission>
     <block subset="none" type="overrides">
-      <para>Para enviar y recibir datos, use el <see cref="M:System.Net.Sockets.TcpClient.GetStream" /> método para obtener un <see cref="T:System.Net.Sockets.NetworkStream" />. Llame a la <see cref="M:System.Net.Sockets.NetworkStream.Write(System.Byte[],System.Int32,System.Int32)" /> y <see cref="M:System.Net.Sockets.NetworkStream.Read(System.Byte[],System.Int32,System.Int32)" /> métodos de la <see cref="T:System.Net.Sockets.NetworkStream" /> para enviar y recibir datos con el host remoto. Use la <see cref="M:System.Net.Sockets.NetworkStream.Close(System.Int32)" /> método para liberar todos los recursos asociados con la <see cref="T:System.Net.Sockets.TcpClient" />.</para>
+      <para>Para enviar y recibir datos, use el método <see cref="M:System.Net.Sockets.TcpClient.GetStream" /> para obtener un <see cref="T:System.Net.Sockets.NetworkStream" />. Llame a los métodos <see cref="M:System.Net.Sockets.NetworkStream.Write(System.Byte[],System.Int32,System.Int32)" /> y <see cref="M:System.Net.Sockets.NetworkStream.Read(System.Byte[],System.Int32,System.Int32)" /> del <see cref="T:System.Net.Sockets.NetworkStream" /> para enviar y recibir datos con el host remoto. Use el método <see cref="M:System.Net.Sockets.NetworkStream.Close(System.Int32)" /> para liberar todos los recursos asociados con el <see cref="T:System.Net.Sockets.TcpClient" />.</para>
     </block>
     <altmember cref="T:System.Net.Sockets.TcpListener" />
     <altmember cref="T:System.Net.Sockets.NetworkStream" />


### PR DESCRIPTION
Change word ordering and articles so that the text reads correctly in Spanish.