### PR TITLE
Fix mistake in automatic translation

### DIFF
--- a/xml/ns-System.Collections.Concurrent.xml
+++ b/xml/ns-System.Collections.Concurrent.xml
@@ -2,7 +2,7 @@
   <Metadata><Meta Name="ms.openlocfilehash" Value="b370791477b82b47c4f82def2754c6fd0f73546d" /><Meta Name="ms.sourcegitcommit" Value="434f60616a9793fa8436744549fc856e94f7a648" /><Meta Name="ms.translationtype" Value="MT" /><Meta Name="ms.contentlocale" Value="es-ES" /><Meta Name="ms.lasthandoff" Value="08/24/2018" /><Meta Name="ms.locfileid" Value="36270692" /></Metadata><Docs>
     <summary>El espacio de nombres <see langword="System.Collections.Concurrent" /> proporciona varias clases de colección seguras para subprocesos que deben usarse en lugar de los tipos correspondientes en los espacios de nombres <see cref="N:System.Collections" /> y <see cref="N:System.Collections.Generic" /> cada vez que varios subprocesos accedan simultáneamente a la colección.  
   
-Sin embargo, el acceso a los elementos de un objeto de colección mediante métodos de extensión o implementaciones de interfaz explícita no tiene garantizado el seguro para subprocesos y es posible que se tenga que sincronizar con el autor de la llamada.</summary>
+Sin embargo, el acceso a los elementos de un objeto de colección mediante métodos de extensión o implementaciones de interfaz explícita no garantiza la seguridad para subprocesos y es posible que tenga que ser sincronizado por el autor de la llamada.</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>

--- a/xml/ns-System.Collections.Concurrent.xml
+++ b/xml/ns-System.Collections.Concurrent.xml
@@ -2,7 +2,7 @@
   <Metadata><Meta Name="ms.openlocfilehash" Value="b370791477b82b47c4f82def2754c6fd0f73546d" /><Meta Name="ms.sourcegitcommit" Value="434f60616a9793fa8436744549fc856e94f7a648" /><Meta Name="ms.translationtype" Value="MT" /><Meta Name="ms.contentlocale" Value="es-ES" /><Meta Name="ms.lasthandoff" Value="08/24/2018" /><Meta Name="ms.locfileid" Value="36270692" /></Metadata><Docs>
     <summary>El espacio de nombres <see langword="System.Collections.Concurrent" /> proporciona varias clases de colección seguras para subprocesos que deben usarse en lugar de los tipos correspondientes en los espacios de nombres <see cref="N:System.Collections" /> y <see cref="N:System.Collections.Generic" /> cada vez que varios subprocesos accedan simultáneamente a la colección.  
   
-Sin embargo, el acceso a los elementos de un objeto de colección mediante métodos de extensión o implementaciones de interfaz explícita no garantiza la seguridad para subprocesos y es posible que tenga que ser sincronizado por el autor de la llamada.</summary>
+Sin embargo, no está garantizado que el acceso a los elementos de un objeto de colección mediante métodos de extensión o mediante implementaciones de interfaz explícitas sea seguro para los subprocesos y es posible que el autor de la llamada tenga que sincronizarlo.</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
The original "synchronized by" had been translated as "sincronizado con" but in this context it means "sincronizado por".